### PR TITLE
If update includes empty field, throw error

### DIFF
--- a/app/routes/post_routes.js
+++ b/app/routes/post_routes.js
@@ -93,6 +93,7 @@ router.patch('/posts/:id', requireToken, (req, res) => {
       Object.keys(req.body.post).forEach(key => {
         if (req.body.post[key] === '') {
           delete req.body.post[key]
+          throw new Error('something for now')
         }
       })
 


### PR DESCRIPTION
This commit features one new line of code in the update PATCH request.
If a field is empty on update, update will fail, update ui will throw
an error, and now change will be made to the data.